### PR TITLE
Add class decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `dataclass-type-validator` is a type validation library for the properties o
 
 ## A Simple Example
 
-
+### Explicitly calling dataclass_type_validator from within your dataclass
 ```python
 from dataclasses import dataclass
 from typing import List
@@ -23,6 +23,37 @@ class User:
 
     def __post_init__(self):
         dataclass_type_validator(self)
+
+
+# Valid User
+User(id=10, name='John Smith', friend_ids=[1, 2])
+# => User(id=10, name='John Smith', friend_ids=[1, 2])
+
+# Invalid User
+try:
+    User(id='a', name=['John', 'Smith'], friend_ids=['a'])
+except TypeValidationError as e:
+    print(e)
+# => TypeValidationError: Dataclass Type Validation (errors = {
+#   'id': "must be an instance of <class 'int'>, but received <class 'str'>",
+#   'name': "must be an instance of <class 'str'>, but received <class 'list'>",
+#   'friend_ids': 'must be an instance of typing.List[int], but there are some errors:
+#       ["must be an instance of <class \'int\'>, but received <class \'str\'>"]'})
+```
+
+### The same, but using the class decorator instead
+```python
+from dataclasses import dataclass
+from typing import List
+from dataclass_type_validator import dataclass_validate
+from dataclass_type_validator import TypeValidationError
+
+@dataclass_validate
+@dataclass()
+class User:
+    id: int
+    name: str
+    friend_ids: List[int]
 
 
 # Valid User

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,7 +2,7 @@ import pytest
 import dataclasses
 import typing
 
-from dataclass_type_validator import dataclass_type_validator
+from dataclass_type_validator import dataclass_type_validator, dataclass_validate
 from dataclass_type_validator import TypeValidationError
 
 
@@ -218,3 +218,58 @@ class TestNestedDataclass:
             assert isinstance(ParentValue(
                 child=None
             ), ParentValue)
+
+
+@dataclass_validate
+@dataclasses.dataclass(frozen=True)
+class DataclassWithPostInitTestDecorator:
+    number: int
+    optional_number: typing.Optional[int] = None
+
+    def __post_init__(self):
+        dataclass_type_validator(self)
+
+
+class TestDecoratorWithPostInit:
+    def test_build_success(self):
+        assert isinstance(DataclassWithPostInitTestDecorator(
+            number=1,
+            optional_number=None,
+        ), DataclassWithPostInitTestDecorator)
+        assert isinstance(DataclassWithPostInitTestDecorator(
+            number=1,
+            optional_number=1
+        ), DataclassWithPostInitTestDecorator)
+
+    def test_build_failure_on_number(self):
+        with pytest.raises(TypeValidationError):
+            assert isinstance(DataclassWithPostInitTestDecorator(
+                number=1,
+                optional_number='string'
+            ), DataclassWithPostInitTestDecorator)
+
+
+@dataclass_validate
+@dataclasses.dataclass(frozen=True)
+class DataclassWithoutPostInitTestDecorator:
+    number: int
+    optional_number: typing.Optional[int] = None
+
+
+class TestDecoratorWithoutPostInit:
+    def test_build_success(self):
+        assert isinstance(DataclassWithoutPostInitTestDecorator(
+            number=1,
+            optional_number=None,
+        ), DataclassWithoutPostInitTestDecorator)
+        assert isinstance(DataclassWithoutPostInitTestDecorator(
+            number=1,
+            optional_number=1
+        ), DataclassWithoutPostInitTestDecorator)
+
+    def test_build_failure_on_number(self):
+        with pytest.raises(TypeValidationError):
+            assert isinstance(DataclassWithoutPostInitTestDecorator(
+                number=1,
+                optional_number='string'
+            ), DataclassWithoutPostInitTestDecorator)


### PR DESCRIPTION
This adds the class decorator function `dataclass_validate()` which can be added with standard decorator syntax to the definition of the class, rather than having to add a `__post_init__()` function to every dataclass manually and remembering to explicitly call `dataclass_type_validator(self)` from that method.

Otherwise, it functions exactly the same.  It just lets you do this:

```
@dataclass_validate
@dataclasses.dataclass(frozen=True)
class MyDataClass:
    foo: str

x = MyDataClass(6)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/charlesc/projects/3rd-party-contributions/dataclass-type-validator/dataclass_type_validator/__init__.py", line 136, in wrapper
    dataclass_type_validator(self, strict=True)
  File "/home/charlesc/projects/3rd-party-contributions/dataclass-type-validator/dataclass_type_validator/__init__.py", line 113, in dataclass_type_validator
    raise TypeValidationError('Dataclass Type Validation Error', errors=errors)
dataclass_type_validator.TypeValidationError: Dataclass Type Validation Error (errors = {'foo': "must be an instance of <class 'str'>, but received <class 'int'>"})
```
