### PR TITLE
Add strict and before_post_init parameters to class decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,38 @@ except TypeValidationError as e:
 #   'friend_ids': 'must be an instance of typing.List[int], but there are some errors:
 #       ["must be an instance of <class \'int\'>, but received <class \'str\'>"]'})
 ```
+You can also pass the `strict` param (which defaults to False) to the decorator:
+```python
+@dataclass_validate(strict=True)
+@dataclass(frozen=True)
+class SomeList:
+    values: List[str]
+
+# Invalid item contained in typed List
+try:
+    SomeList(values=["one", "two", 3])
+except TypeValidationError as e:
+    print(e)
+# => TypeValidationError: Dataclass Type Validation Error (errors = {
+#   'x': 'must be an instance of typing.List[str], but there are some errors: 
+#       ["must be an instance of <class \'str\'>, but received <class \'int\'>"]'})
+```
+
+You can also pass the `before_post_init` param (which defaults to False) to the decorator,
+to force the type validation to occur before `__post_init__()` is called.  This can be used
+to ensure the types of the field values have been validated before your higher-level semantic
+validation is performed in `__post_init__()`.
+```python
+@dataclass_validate(before_post_init=True)
+@dataclass
+class User:
+    id: int
+    name: str
+
+    def __post_init__(self):
+        # types of id and name have already been checked before this is called.
+        # Otherwise, the following check will throw a TypeError if user passed 
+        # `id` as a string or other type that cannot be compared to int.
+        if id < 1:
+            raise ValueError("superuser not allowed")
+```

--- a/dataclass_type_validator/__init__.py
+++ b/dataclass_type_validator/__init__.py
@@ -113,27 +113,39 @@ def dataclass_type_validator(target, strict: bool = False):
         raise TypeValidationError('Dataclass Type Validation Error', errors=errors)
 
 
-def dataclass_validate(cls):
+def dataclass_validate(cls=None, *, strict: bool = False, before_post_init: bool = False):
     """Dataclass decorator to automatically add validation to a dataclass.
 
     So you don't have to add a __post_init__ method, or if you have one, you don't have
     to remember to add the dataclass_type_validator(self) call to it; just decorate your
     dataclass with this instead.
+
+    :param strict: bool
+    :param before_post_init: bool - if True, force the validation logic to occur before
+        __post_init__ is called.  Only has effect if the class defines __post_init__.
+        This setting allows you to ensure the field values are already validated to
+        be the correct type before any additional logic in __post_init__ does further
+        validation.  Default: False.
     """
-    if hasattr(cls, "__post_init__"):
-        wrapped_func_name = "__post_init__"
+    if cls is None:
+        return functools.partial(dataclass_validate, strict=strict, before_post_init=before_post_init)
+
+    if before_post_init or not hasattr(cls, "__post_init__"):
+        # Either the user wants to force the validation to occur before __post_init__ is called,
+        # or the dataclass has no __post_init__ (which means there's no post-init processing
+        # taking place), so we wrap the constructor instead.
+        wrapped_method_name = "__init__"
     else:
-        # No __post_init__ to wrap, but it means there's no post-init processing
-        # taking place, so we can wrap the constructor instead.
-        wrapped_func_name = "__init__"
-    orig_func = getattr(cls, wrapped_func_name)
+        # Normally make validation take place at the end of __post_init__
+        wrapped_method_name = "__post_init__"
 
-    @functools.wraps(orig_func)
-    def wrapper(self, *args, **kwargs):
-        # Call constructor or __post_init__ as appropriate
-        orig_func(self, *args, **kwargs)
-        # And then do validation
-        dataclass_type_validator(self, strict=True)
+    orig_method = getattr(cls, wrapped_method_name)
 
-    setattr(cls, wrapped_func_name, wrapper)
+    @functools.wraps(orig_method)
+    def method_wrapper(self, *args, **kwargs):
+        x = orig_method(self, *args, **kwargs)
+        dataclass_type_validator(self, strict=strict)
+        return x
+    setattr(cls, wrapped_method_name, method_wrapper)
+
     return cls

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -243,10 +243,10 @@ class TestDecoratorWithPostInit:
 
     def test_build_failure_on_number(self):
         with pytest.raises(TypeValidationError):
-            assert isinstance(DataclassWithPostInitTestDecorator(
+            _ = DataclassWithPostInitTestDecorator(
                 number=1,
                 optional_number='string'
-            ), DataclassWithPostInitTestDecorator)
+            )
 
 
 @dataclass_validate
@@ -269,7 +269,26 @@ class TestDecoratorWithoutPostInit:
 
     def test_build_failure_on_number(self):
         with pytest.raises(TypeValidationError):
-            assert isinstance(DataclassWithoutPostInitTestDecorator(
+            _ = DataclassWithoutPostInitTestDecorator(
                 number=1,
                 optional_number='string'
-            ), DataclassWithoutPostInitTestDecorator)
+            )
+
+
+@dataclass_validate(strict=True)
+@dataclasses.dataclass(frozen=True)
+class DataclassWithStrictChecking:
+    values: typing.List[int]
+
+
+class TestDecoratorStrict:
+    def test_build_success(self):
+        assert isinstance(DataclassWithStrictChecking(
+            values=[1, 2, 3],
+        ), DataclassWithStrictChecking)
+
+    def test_build_failure_on_number(self):
+        with pytest.raises(TypeValidationError):
+            _ = DataclassWithStrictChecking(
+                values=[1, 2, "three"],
+            )


### PR DESCRIPTION
I recently ran into an issue where I wanted the basic field value validation to run before my __post_init__ method (as it did higher-level semantic validation and that was easier if I could rely on the basic constructor types to already be type-correct).

This adds an optional decorator parameter `before_post_init` to allow this (bool, default False).

For good measure, it also adds the `strict` parameter to the decorator (also optional), which it passes through to `dataclass_type_validator`.

The defaults for both match the previous behaviour, so there are no compatibility problems.
