### PR TITLE
Added support for ForwardRef types

### DIFF
--- a/dataclass_type_validator/__init__.py
+++ b/dataclass_type_validator/__init__.py
@@ -1,9 +1,12 @@
 import dataclasses
 import typing
 import functools
+import sys
 from typing import Any
 from typing import Optional
+from typing import Dict
 
+GlobalNS_Type = Dict[str, Any]
 
 class TypeValidationError(Exception):
     """Exception raised on type validation errors.
@@ -40,43 +43,43 @@ def _validate_type(expected_type: type, value: Any) -> Optional[str]:
         return f'must be an instance of {expected_type}, but received {type(value)}'
 
 
-def _validate_iterable_items(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_iterable_items(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     expected_item_type = expected_type.__args__[0]
-    errors = [_validate_types(expected_type=expected_item_type, value=v, strict=strict) for v in value]
+    errors = [_validate_types(expected_type=expected_item_type, value=v, strict=strict, globalns=globalns) for v in value]
     errors = [x for x in errors if x]
     if len(errors) > 0:
         return f'must be an instance of {expected_type}, but there are some errors: {errors}'
 
 
-def _validate_typing_list(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_typing_list(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     if not isinstance(value, list):
         return f'must be an instance of list, but received {type(value)}'
-    return _validate_iterable_items(expected_type, value, strict)
+    return _validate_iterable_items(expected_type, value, strict, globalns)
 
 
-def _validate_typing_tuple(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_typing_tuple(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     if not isinstance(value, tuple):
         return f'must be an instance of tuple, but received {type(value)}'
-    return _validate_iterable_items(expected_type, value, strict)
+    return _validate_iterable_items(expected_type, value, strict, globalns)
 
 
-def _validate_typing_frozenset(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_typing_frozenset(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     if not isinstance(value, frozenset):
         return f'must be an instance of frozenset, but received {type(value)}'
-    return _validate_iterable_items(expected_type, value, strict)
+    return _validate_iterable_items(expected_type, value, strict, globalns)
 
 
-def _validate_typing_dict(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_typing_dict(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     if not isinstance(value, dict):
         return f'must be an instance of dict, but received {type(value)}'
 
     expected_key_type = expected_type.__args__[0]
     expected_value_type = expected_type.__args__[1]
 
-    key_errors = [_validate_types(expected_type=expected_key_type, value=k, strict=strict) for k in value.keys()]
+    key_errors = [_validate_types(expected_type=expected_key_type, value=k, strict=strict, globalns=globalns) for k in value.keys()]
     key_errors = [k for k in key_errors if k]
 
-    val_errors = [_validate_types(expected_type=expected_value_type, value=v, strict=strict) for v in value.values()]
+    val_errors = [_validate_types(expected_type=expected_value_type, value=v, strict=strict, globalns=globalns) for v in value.values()]
     val_errors = [v for v in val_errors if v]
 
     if len(key_errors) > 0 and len(val_errors) > 0:
@@ -88,7 +91,7 @@ def _validate_typing_dict(expected_type: type, value: Any, strict: bool) -> Opti
         return f'must be an instance of {expected_type}, but there are some errors in values: {val_errors}'
 
 
-def _validate_typing_callable(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_typing_callable(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     _ = strict
     if not isinstance(value, type(lambda a: a)):
         return f'must be an instance of {expected_type._name}, but received {type(value)}'
@@ -109,35 +112,41 @@ _validate_typing_mappings = {
 }
 
 
-def _validate_sequential_types(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_sequential_types(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     validate_func = _validate_typing_mappings.get(expected_type._name)
     if validate_func is not None:
-        return validate_func(expected_type, value, strict)
+        return validate_func(expected_type, value, strict, globalns)
 
     if str(expected_type).startswith('typing.Literal'):
         return _validate_typing_literal(expected_type, value, strict)
 
-    if str(expected_type).startswith('typing.Union'):
-        is_valid = any(_validate_types(expected_type=t, value=value, strict=strict) is None
+    if str(expected_type).startswith('typing.Union') or str(expected_type).startswith('typing.Optional'):
+        is_valid = any(_validate_types(expected_type=t, value=value, strict=strict, globalns=globalns) is None
                        for t in expected_type.__args__)
         if not is_valid:
             return f'must be an instance of {expected_type}, but received {value}'
         return
 
+
     if strict:
         raise RuntimeError(f'Unknown type of {expected_type} (_name = {expected_type._name})')
 
 
-def _validate_types(expected_type: type, value: Any, strict: bool) -> Optional[str]:
+def _validate_types(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_Type) -> Optional[str]:
     if isinstance(expected_type, type):
         return _validate_type(expected_type=expected_type, value=value)
 
     if isinstance(expected_type, typing._GenericAlias):
-        return _validate_sequential_types(expected_type=expected_type, value=value, strict=strict)
+        return _validate_sequential_types(expected_type=expected_type, value=value, strict=strict, globalns=globalns)
+
+    if isinstance(expected_type, typing.ForwardRef):
+        referenced_type = expected_type._evaluate(globalns, None, set())
+        return _validate_type(expected_type=referenced_type, value=value)
 
 
 def dataclass_type_validator(target, strict: bool = False):
     fields = dataclasses.fields(target)
+    globalns = sys.modules[target.__module__].__dict__.copy()
 
     errors = {}
     for field in fields:
@@ -145,7 +154,7 @@ def dataclass_type_validator(target, strict: bool = False):
         expected_type = field.type
         value = getattr(target, field_name)
 
-        err = _validate_types(expected_type=expected_type, value=value, strict=strict)
+        err = _validate_types(expected_type=expected_type, value=value, strict=strict, globalns=globalns)
         if err is not None:
             errors[field_name] = err
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -103,7 +103,7 @@ class TestTypeValidationList:
 
     def test_build_failure_on_array_optional_strings(self):
         with pytest.raises(TypeValidationError,
-                           match="must be an instance of typing.List\\[typing.Union\\[(str, NoneType|NoneType, str)\\]\\]"):
+                           match="must be an instance of typing.List\\[typing.Optional\\[(str)\\]\\]"):
             assert isinstance(DataclassTestList(
                 array_of_numbers=[1, 2],
                 array_of_strings=['abc'],
@@ -138,7 +138,7 @@ class TestTypeValidationUnion:
                 optional_string=None
             ), DataclassTestUnion)
 
-        with pytest.raises(TypeValidationError, match='must be an instance of typing.Union\\[str, NoneType\\]'):
+        with pytest.raises(TypeValidationError, match='must be an instance of typing.Optional\\[str\\]'):
             assert isinstance(DataclassTestUnion(
                 string_or_number=123,
                 optional_string=123
@@ -217,6 +217,34 @@ class TestTypeValidationCallable:
             assert isinstance(DataclassTestCallable(
                 func=None,
             ), DataclassTestCallable)
+
+
+@dataclasses.dataclass(frozen=True)
+class DataclassTestForwardRef:
+    number: 'int'
+    ref: typing.Optional['DataclassTestForwardRef'] = None
+
+    def __post_init__(self):
+        dataclass_type_validator(self)
+
+
+class TestTypeValidationForwardRef:
+    def test_build_success(self):
+        assert isinstance(DataclassTestForwardRef(
+            number=1,
+            ref=None,
+        ), DataclassTestForwardRef)
+        assert isinstance(DataclassTestForwardRef(
+            number=1,
+            ref=DataclassTestForwardRef(2, None)
+        ), DataclassTestForwardRef)
+
+    def test_build_failure_on_number(self):
+        with pytest.raises(TypeValidationError):
+            assert isinstance(DataclassTestForwardRef(
+                number=1,
+                ref='string'
+            ), DataclassTestForwardRef)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
This pull request is to address #14.

Added code to evaluate typing.ForwardRef types. These are generally used to
reference types that haven't been defined yet. Unfortunately to evaluate
these types you need to pass a dictionary containing all the globals to all
the validate functions so that the type can be evaluated. This has meant
that many lines had to updated just to add the additional argument.

Also had to add special handling of the Optional type to enable the
tests to pass on Python 3.9.