### PR TITLE
Get python 3.9 Working

### DIFF
--- a/dataclass_type_validator/__init__.py
+++ b/dataclass_type_validator/__init__.py
@@ -117,7 +117,7 @@ def _validate_sequential_types(expected_type: type, value: Any, strict: bool) ->
     if str(expected_type).startswith('typing.Literal'):
         return _validate_typing_literal(expected_type, value, strict)
 
-    if str(expected_type).startswith('typing.Union'):
+    if str(expected_type).startswith('typing.Union') or str(expected_type).startswith('typing.Optional'):
         is_valid = any(_validate_types(expected_type=t, value=value, strict=strict) is None
                        for t in expected_type.__args__)
         if not is_valid:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,7 @@
 import pytest
 import dataclasses
 import typing
+import sys
 
 from dataclass_type_validator import dataclass_type_validator, dataclass_validate
 from dataclass_type_validator import TypeValidationError
@@ -103,7 +104,7 @@ class TestTypeValidationList:
 
     def test_build_failure_on_array_optional_strings(self):
         with pytest.raises(TypeValidationError,
-                           match="must be an instance of typing.List\\[typing.Union\\[(str, NoneType|NoneType, str)\\]\\]"):
+                           match=f"must be an instance of typing.List\\[{optional_type_name('str')}\\]"):
             assert isinstance(DataclassTestList(
                 array_of_numbers=[1, 2],
                 array_of_strings=['abc'],
@@ -138,7 +139,7 @@ class TestTypeValidationUnion:
                 optional_string=None
             ), DataclassTestUnion)
 
-        with pytest.raises(TypeValidationError, match='must be an instance of typing.Union\\[str, NoneType\\]'):
+        with pytest.raises(TypeValidationError, match=f'must be an instance of {optional_type_name("str")}'):
             assert isinstance(DataclassTestUnion(
                 string_or_number=123,
                 optional_string=123
@@ -321,3 +322,13 @@ class TestDecoratorStrict:
             _ = DataclassWithStrictChecking(
                 values=[1, 2, "three"],
             )
+
+def optional_type_name(arg_type_name):
+    """ Gets the typename string for an typing.Optional.
+        On python 3.8 an Optional[int] is converted to a typing.Union[int, NoneType].
+        On python 3.9 it remains unchanged as Optional[int].
+    """
+    if sys.version_info < (3, 9):
+        return f"typing.Union\\[({arg_type_name}, NoneType|NoneType, {arg_type_name})\\]"
+
+    return f"typing.Optional\\[{arg_type_name}\\]"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -323,6 +323,7 @@ class TestDecoratorStrict:
                 values=[1, 2, "three"],
             )
 
+
 def optional_type_name(arg_type_name):
     """ Gets the typename string for an typing.Optional.
         On python 3.8 an Optional[int] is converted to a typing.Union[int, NoneType].


### PR DESCRIPTION
Splitting out the support for python 3.9, whilst maintaining backwards compatibility with 3.8 from pull request #15.