### PR TITLE
Add PEP 585 support for python 3.9+

### DIFF
--- a/dataclass_type_validator/__init__.py
+++ b/dataclass_type_validator/__init__.py
@@ -9,6 +9,7 @@ import types
 
 GlobalNS_T = Dict[str, Any]
 
+
 class TypeValidationError(Exception):
     """Exception raised on type validation errors.
     """

--- a/dataclass_type_validator/__init__.py
+++ b/dataclass_type_validator/__init__.py
@@ -113,6 +113,7 @@ _validate_typing_mappings = {
     'Tuple': _validate_typing_tuple,
     'tuple': _validate_typing_tuple,
     'FrozenSet': _validate_typing_frozenset,
+    'frozenset': _validate_typing_frozenset,
     'Dict': _validate_typing_dict,
     'dict': _validate_typing_dict,
     'Callable': _validate_typing_callable,

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -199,8 +199,6 @@ class TestTypeValidationDict:
             ), DataclassTestDict)
 
 
-
-
 @dataclasses.dataclass(frozen=True)
 class DataclassTestCallable:
     func: typing.Callable[[int, int], int]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -199,6 +199,8 @@ class TestTypeValidationDict:
             ), DataclassTestDict)
 
 
+
+
 @dataclasses.dataclass(frozen=True)
 class DataclassTestCallable:
     func: typing.Callable[[int, int], int]
@@ -361,3 +363,77 @@ def optional_type_name(arg_type_name):
         return f"typing.Union\\[({arg_type_name}, NoneType|NoneType, {arg_type_name})\\]"
 
     return f"typing.Optional\\[{arg_type_name}\\]"
+
+# Tests for generic types, only in 3.9+
+if sys.version_info >= (3, 9):
+
+    @dataclasses.dataclass(frozen=True)
+    class DataclassTestGenericList:
+        array_of_numbers: list[int]
+        array_of_strings: list[str]
+        array_of_optional_strings: list[typing.Optional[str]]
+
+        def __post_init__(self):
+            dataclass_type_validator(self)
+
+
+    class TestTypeValidationGenericList:
+        def test_build_success(self):
+            assert isinstance(DataclassTestGenericList(
+                array_of_numbers=[],
+                array_of_strings=[],
+                array_of_optional_strings=[],
+            ), DataclassTestGenericList)
+            assert isinstance(DataclassTestGenericList(
+                array_of_numbers=[1, 2],
+                array_of_strings=['abc'],
+                array_of_optional_strings=['abc', None]
+            ), DataclassTestGenericList)
+
+        def test_build_failure_on_array_numbers(self):
+            with pytest.raises(TypeValidationError, match='must be an instance of list\\[int\\]'):
+                assert isinstance(DataclassTestGenericList(
+                    array_of_numbers=['abc'],
+                    array_of_strings=['abc'],
+                    array_of_optional_strings=['abc', None]
+                ), DataclassTestGenericList)
+
+        def test_build_failure_on_array_strings(self):
+            with pytest.raises(TypeValidationError, match='must be an instance of list\\[str\\]'):
+                assert isinstance(DataclassTestGenericList(
+                    array_of_numbers=[1, 2],
+                    array_of_strings=[123],
+                    array_of_optional_strings=['abc', None]
+                ), DataclassTestGenericList)
+
+        def test_build_failure_on_array_optional_strings(self):
+            with pytest.raises(TypeValidationError,
+                               match=f"must be an instance of list\\[{optional_type_name('str')}\\]"):
+                assert isinstance(DataclassTestGenericList(
+                    array_of_numbers=[1, 2],
+                    array_of_strings=['abc'],
+                    array_of_optional_strings=[123, None]
+                ), DataclassTestGenericList)
+
+    @dataclasses.dataclass(frozen=True)
+    class DataclassTestGenericDict:
+        str_to_str: dict[str, str]
+        str_to_any: dict[str, typing.Any]
+
+        def __post_init__(self):
+            dataclass_type_validator(self)
+
+
+    class TestTypeValidationGenericDict:
+        def test_build_success(self):
+            assert isinstance(DataclassTestGenericDict(
+                str_to_str={'str': 'str'},
+                str_to_any={'str': 'str', 'str2': 123}
+            ), DataclassTestGenericDict)
+
+        def test_build_failure(self):
+            with pytest.raises(TypeValidationError, match='must be an instance of dict\\[str, str\\]'):
+                assert isinstance(DataclassTestGenericDict(
+                    str_to_str={'str': 123},
+                    str_to_any={'key': []}
+                ), DataclassTestGenericDict)


### PR DESCRIPTION
Currently, this package doesn't support [PEP 585](https://peps.python.org/pep-0585/). And the stack trace is a little confusing.

For example:
```python
In [1]: from dataclasses import dataclass

In [2]: from dataclass_type_validator import dataclass_validate

In [3]: from typing import List

In [4]: @dataclass_validate
   ...: @dataclass
   ...: class Foo:
   ...:     bar: list[str]
   ...:     baz: List[str]
   ...: 

In [5]: Foo(bar=["bar"], baz=["baz"])
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[6], line 1
----> 1 Foo(bar=["bar"], baz=["baz"])

File ~/.pyenv/versions/3.9.10/envs/science-3.9.10/lib/python3.9/site-packages/dataclass_type_validator/__init__.py:216, in dataclass_validate.<locals>.method_wrapper(self, *args, **kwargs)
    213 @functools.wraps(orig_method)
    214 def method_wrapper(self, *args, **kwargs):
    215     x = orig_method(self, *args, **kwargs)
--> 216     dataclass_type_validator(self, strict=strict)
    217     return x

File ~/.pyenv/versions/3.9.10/envs/science-3.9.10/lib/python3.9/site-packages/dataclass_type_validator/__init__.py:168, in dataclass_type_validator(target, strict)
    165 expected_type = field.type
    166 value = getattr(target, field_name)
--> 168 err = _validate_types(expected_type=expected_type, value=value, strict=strict, globalns=globalns)
    169 if err is not None:
    170     errors[field_name] = err

File ~/.pyenv/versions/3.9.10/envs/science-3.9.10/lib/python3.9/site-packages/dataclass_type_validator/__init__.py:140, in _validate_types(expected_type, value, strict, globalns)
    138 def _validate_types(expected_type: type, value: Any, strict: bool, globalns: GlobalNS_T) -> Optional[str]:
    139     if isinstance(expected_type, type):
--> 140         return _validate_type(expected_type=expected_type, value=value)
    142     if isinstance(expected_type, typing._GenericAlias):
    143         return _validate_sequential_types(expected_type=expected_type, value=value,
    144                                           strict=strict, globalns=globalns)

File ~/.pyenv/versions/3.9.10/envs/science-3.9.10/lib/python3.9/site-packages/dataclass_type_validator/__init__.py:43, in _validate_type(expected_type, value)
     42 def _validate_type(expected_type: type, value: Any) -> Optional[str]:
---> 43     if not isinstance(value, expected_type):
     44         return f'must be an instance of {expected_type}, but received {type(value)}'

TypeError: isinstance() argument 2 cannot be a parameterized generic
```

This was confusing to me and it seems to other users (see: https://github.com/levii/dataclass-type-validator/issues/20).

This PR adds support for generic type aliases while still maintaining backward compatibility with 3.8 (via some ugly version checks).